### PR TITLE
update for new gleam so project compiles and works

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.4
         with:
           otp-version: "25.2"
-          gleam-version: "0.29.0"
+          gleam-version: "0.34.0"
           rebar3-version: "3"
           # elixir-version: "1.14.2"
       - run: gleam format --check src test

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,19 +1,21 @@
 name = "halo"
-version = "0.1.0"
+version = "1.0.0"
 description = "A Gleam project"
 
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "PROMETHIA-27", repo = "halo" }
 
 [dependencies]
-gleam_stdlib = "~> 0.29"
+gleam_stdlib = "~> 0.35"
 fs = "~> 8.6"
 gleam_erlang = "~> 0.19"
 shellout = "~> 1.3"
 tomerl = "~> 0.5"
+simplifile = "~> 1.4"
 
 [dev-dependencies]
-gleeunit = "~> 0.10"
+gleeunit = "~> 1.0"
+
 
 [mote]
 bin_whitelist = [

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,17 +3,19 @@
 
 packages = [
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
-  { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
-  { name = "gleam_stdlib", version = "0.29.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "24581B17879AA903B3E7531869D9460730C2F772A1C02C774ABF75710CCC4CFE" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
-  { name = "shellout", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "shellout", source = "hex", outer_checksum = "2F0BFBA7E8D18427525EE8611E832D59D72D261FFA533A3C0DD86987383A53A5" },
+  { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
+  { name = "gleam_stdlib", version = "0.35.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5443EEB74708454B65650FEBBB1EF5175057D1DEC62AEA9D7C6D96F41DA79152" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
+  { name = "simplifile", version = "1.4.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C93A62CE23B2E44F969DC3134F9EE899C362B0A2F4181233CDD5D759F82EE486" },
   { name = "tomerl", version = "0.5.0", build_tools = ["rebar3"], requirements = [], otp_app = "tomerl", source = "hex", outer_checksum = "2A7FB62F9EBF0E75561B39255638BC2B805B437C86FEC538657E7C3B576979FA" },
 ]
 
 [requirements]
-fs = "~> 8.6"
-gleam_erlang = "~> 0.19"
-gleam_stdlib = "~> 0.29"
-gleeunit = "~> 0.10"
-shellout = "~> 1.3"
-tomerl = "~> 0.5"
+fs = { version = "~> 8.6" }
+gleam_erlang = { version = "~> 0.19" }
+gleam_stdlib = { version = "~> 0.35" }
+gleeunit = { version = "~> 1.0" }
+shellout = { version = "~> 1.3" }
+simplifile = { version = "~> 1.4"}
+tomerl = { version = "~> 0.5" }

--- a/src/halo/code.gleam
+++ b/src/halo/code.gleam
@@ -15,15 +15,12 @@ pub fn soft_purge(module: Module) -> Bool
 pub fn module_name(module: Module) -> String
 
 pub fn soft_purge_all(modules: List(Module)) -> Result(Nil, Module) {
-  list.try_each(
-    modules,
-    fn(mod) {
-      case soft_purge(mod) {
-        True -> Ok(Nil)
-        False -> Error(mod)
-      }
-    },
-  )
+  list.try_each(modules, fn(mod) {
+    case soft_purge(mod) {
+      True -> Ok(Nil)
+      False -> Error(mod)
+    }
+  })
 }
 
 pub fn add_paths(paths: List(String)) -> modres.ModuleResult {
@@ -34,6 +31,4 @@ pub fn add_paths(paths: List(String)) -> modres.ModuleResult {
 }
 
 @external(erlang, "code", "add_paths")
-pub fn add_paths_internal(
-  paths: List(charlist.Charlist),
-) -> modres.ModuleResult
+pub fn add_paths_internal(paths: List(charlist.Charlist)) -> modres.ModuleResult

--- a/src/halo/code.gleam
+++ b/src/halo/code.gleam
@@ -1,18 +1,18 @@
 import gleam/list
-import halo/modres.{Module}
+import halo/modres.{type Module}
 import gleam/erlang/charlist
 
-pub external fn modified_modules() -> List(Module) =
-  "code" "modified_modules"
+@external(erlang, "code", "modified_modules")
+pub fn modified_modules() -> List(Module)
 
-pub external fn atomic_load(List(Module)) -> modres.ModuleResult =
-  "code" "atomic_load"
+@external(erlang, "code", "atomic_load")
+pub fn atomic_load(module_lst: List(Module)) -> modres.ModuleResult
 
-pub external fn soft_purge(Module) -> Bool =
-  "code" "soft_purge"
+@external(erlang, "code", "soft_purge")
+pub fn soft_purge(module: Module) -> Bool
 
-pub external fn module_name(Module) -> String =
-  "halo_erl" "module_name"
+@external(erlang, "halo_erl", "module_name")
+pub fn module_name(module: Module) -> String
 
 pub fn soft_purge_all(modules: List(Module)) -> Result(Nil, Module) {
   list.try_each(
@@ -33,7 +33,7 @@ pub fn add_paths(paths: List(String)) -> modres.ModuleResult {
   add_paths_internal(paths)
 }
 
-pub external fn add_paths_internal(
+@external(erlang, "code", "add_paths")
+pub fn add_paths_internal(
   paths: List(charlist.Charlist),
-) -> modres.ModuleResult =
-  "code" "add_paths"
+) -> modres.ModuleResult

--- a/src/halo/fs.gleam
+++ b/src/halo/fs.gleam
@@ -1,12 +1,12 @@
 import gleam/erlang/atom
 import gleam/erlang/process
 
-pub external type LinkError
+pub type LinkError
 
-pub external type SubscribeResult
+pub type SubscribeResult
 
-pub external fn start_link(watcher: atom.Atom) -> Result(process.Pid, LinkError) =
-  "fs" "start_link"
+@external(erlang, "fs", "start_link")
+pub fn start_link(watcher: atom.Atom) -> Result(process.Pid, LinkError)
 
-pub external fn subscribe(watcher: atom.Atom) -> SubscribeResult =
-  "fs" "subscribe"
+@external(erlang, "fs", "subscribe")
+pub fn subscribe(watcher: atom.Atom) -> SubscribeResult

--- a/src/halo/modres.gleam
+++ b/src/halo/modres.gleam
@@ -1,6 +1,6 @@
 //// Had to move this type to a new module so it didn't collide with `Result`
 
-pub external type Module
+pub type Module
 
 pub type ModuleResult {
   Ok

--- a/src/halo/shell.gleam
+++ b/src/halo/shell.gleam
@@ -7,5 +7,5 @@ pub type AlreadyStarted {
   AlreadyStarted
 }
 
-pub external fn start() -> ShellResult =
-  "shell" "start_interactive"
+@external(erlang, "shell", "start_interactive")
+pub fn start() -> ShellResult


### PR DESCRIPTION
Updates some dependencies (stdlib update + pull in simplifile since gleam_erlang no longer has fs module).
Updates FFI glue to new `@external` syntax`
This makes it so `gleam add halo --dev` and `gleam run -m halo` works again :) 

This shell is so f%$#ing useful btw, thank you for making it!!!